### PR TITLE
[feat] #32 모든 모임 조회 API 구현

### DIFF
--- a/src/main/java/com/example/leetsgarden/LeetsGardenApplication.java
+++ b/src/main/java/com/example/leetsgarden/LeetsGardenApplication.java
@@ -2,9 +2,6 @@ package com.example.leetsgarden;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @SpringBootApplication
 public class LeetsGardenApplication {
@@ -12,16 +9,4 @@ public class LeetsGardenApplication {
     public static void main(String[] args) {
         SpringApplication.run(LeetsGardenApplication.class, args);
     }
-
-    /*@Bean
-    public WebMvcConfigurer corsConfigurer() {
-        return new WebMvcConfigurer() {
-            @Override
-            public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/**")
-                        .allowedOrigins("*")
-                        .allowedMethods("*");
-            }
-        };
-    }*/
 }

--- a/src/main/java/com/example/leetsgarden/controller/MeetingApiController.java
+++ b/src/main/java/com/example/leetsgarden/controller/MeetingApiController.java
@@ -3,6 +3,7 @@ package com.example.leetsgarden.controller;
 import com.example.leetsgarden.domain.Meeting;
 import com.example.leetsgarden.dto.request.AddMeetingRequest;
 import com.example.leetsgarden.dto.request.UpdateMeetingRequest;
+import com.example.leetsgarden.dto.response.MeetingIdNameResponse;
 import com.example.leetsgarden.dto.response.MeetingResponse;
 import com.example.leetsgarden.service.MeetingService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -32,7 +33,7 @@ public class MeetingApiController {
 
     @Operation(summary = "생성된 모임 조회", description = "생성한 모임을 조회합니다.", tags = {"MeetingApiController"})
     @GetMapping("/{id}")
-    public ResponseEntity<MeetingResponse> findById(@Parameter(name = "id", description = "meeting 의 id", in = ParameterIn.PATH)@PathVariable Long id) {
+    public ResponseEntity<MeetingResponse> findById(@Parameter(name = "id", description = "meeting 의 id", in = ParameterIn.PATH) @PathVariable Long id) {
         Meeting meeting = meetingService.findById(id);
         return ResponseEntity.ok().body(MeetingResponse.from(meeting));
     }
@@ -46,8 +47,14 @@ public class MeetingApiController {
 
     @Operation(summary = "모임수정", description = "모임의 세부정보를 수정할 수 있습니다. ", tags = {"MeetingApiController"})
     @PatchMapping("/{id}")
-    public ResponseEntity<MeetingResponse> update(@Parameter(name = "id", description = "meeting 의 id", in = ParameterIn.PATH)@PathVariable Long id, @RequestBody UpdateMeetingRequest request) {
+    public ResponseEntity<MeetingResponse> update(@Parameter(name = "id", description = "meeting 의 id", in = ParameterIn.PATH) @PathVariable Long id, @RequestBody UpdateMeetingRequest request) {
         Meeting updatedMeeting = meetingService.updateById(id, request);
         return ResponseEntity.ok().body(MeetingResponse.from(updatedMeeting));
+    }
+
+    @Operation(summary = "모든 모임 조회", description = "모든 모임을 조회합니다.", tags = {"MeetingApiController"})
+    @GetMapping("/all")
+    public ResponseEntity<List<MeetingIdNameResponse>> findAll(){
+        return ResponseEntity.ok().body(meetingService.findAll());
     }
 }

--- a/src/main/java/com/example/leetsgarden/dto/response/MeetingIdNameResponse.java
+++ b/src/main/java/com/example/leetsgarden/dto/response/MeetingIdNameResponse.java
@@ -1,0 +1,21 @@
+package com.example.leetsgarden.dto.response;
+
+import com.example.leetsgarden.domain.Meeting;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MeetingIdNameResponse {
+
+    private Long id;
+
+    private String name;
+
+    public static MeetingIdNameResponse from(Meeting meeting) {
+        return MeetingIdNameResponse.builder()
+                .id(meeting.getId())
+                .name(meeting.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/example/leetsgarden/service/MeetingService.java
+++ b/src/main/java/com/example/leetsgarden/service/MeetingService.java
@@ -4,6 +4,7 @@ import com.example.leetsgarden.domain.Meeting;
 import com.example.leetsgarden.domain.User;
 import com.example.leetsgarden.dto.request.AddMeetingRequest;
 import com.example.leetsgarden.dto.request.UpdateMeetingRequest;
+import com.example.leetsgarden.dto.response.MeetingIdNameResponse;
 import com.example.leetsgarden.dto.response.MeetingResponse;
 import com.example.leetsgarden.repository.MeetingRepository;
 import com.example.leetsgarden.repository.UserRepository;
@@ -48,7 +49,7 @@ public class MeetingService {
                 .filter(s -> s.getUserMeetings()
                         .stream()
                         .anyMatch(userMeeting -> userMeeting.getUser().equals(user)))
-                .map(meeting -> MeetingResponse.from(meeting))
+                .map(MeetingResponse::from)
                 .toList();
     }
 
@@ -57,5 +58,11 @@ public class MeetingService {
         Meeting meeting = meetingRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다"));
         meeting.update(request, userRepository);
         return meeting;
+    }
+
+    public List<MeetingIdNameResponse> findAll() {
+        return meetingRepository.findAll().stream()
+                .map(MeetingIdNameResponse::from)
+                .toList();
     }
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
모임별로 출석체크 확인을 위해 모임의 id와 name이 필요합니다.
따라서 위 사항을 조회하는 API를 구현했습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
없습니다.
<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="487" alt="스크린샷 2023-12-01 오후 5 28 14" src="https://github.com/Leets-Official/Leets-Garden-BE/assets/123073840/a57fb071-acbc-4737-89fe-ab0ccca31197">
<br>

## 4. 완료 사항
모임의 id와 name을 조회하는 API를 구현했습니다.
<br>

## 5. 추가 사항
close #31 