### PR TITLE
Feat/#34/미팅 반환값 수정

### DIFF
--- a/src/main/java/com/example/leetsgarden/dto/response/MeetingIdNameResponse.java
+++ b/src/main/java/com/example/leetsgarden/dto/response/MeetingIdNameResponse.java
@@ -9,13 +9,14 @@ import lombok.Getter;
 public class MeetingIdNameResponse {
 
     private Long id;
-
     private String name;
+    private String meetingDay;
 
     public static MeetingIdNameResponse from(Meeting meeting) {
         return MeetingIdNameResponse.builder()
                 .id(meeting.getId())
                 .name(meeting.getName())
+                .meetingDay(meeting.getMeetingDay())
                 .build();
     }
 }

--- a/src/main/java/com/example/leetsgarden/dto/response/MeetingResponse.java
+++ b/src/main/java/com/example/leetsgarden/dto/response/MeetingResponse.java
@@ -1,12 +1,12 @@
 package com.example.leetsgarden.dto.response;
 
 import com.example.leetsgarden.domain.Meeting;
-import com.example.leetsgarden.domain.User;
 import com.example.leetsgarden.domain.UserMeeting;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -20,7 +20,7 @@ public class MeetingResponse {
 
     private String meetingDay;
 
-    private List<User> userList;
+    private List<String> userList;
 
     public static MeetingResponse from(Meeting meeting) {
         MeetingResponse meetingResponse = MeetingResponse.builder()
@@ -33,8 +33,8 @@ public class MeetingResponse {
         List<UserMeeting> userMeetings = meeting.getUserMeetings();
 
         meetingResponse.userList = userMeetings.stream()
-                .map(UserMeeting::getUser)
-                .toList();
+                .map(userMeeting -> userMeeting.getUser().getName())
+                .collect(Collectors.toList());
 
         return meetingResponse;
     }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
미팅 조회시 반환값을 수정하기 위함입니다.
1. 모든 미팅 조회시 날짜를 반환합니다.
2. 특정 미팅 조회시 참가하는 구성원의 이름을 반환합니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
해당 사항 없습니다.
<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="232" alt="image" src="https://github.com/Leets-Official/Leets-Garden-BE/assets/129377887/752297e3-17cf-41b7-8052-29d49dd1a0c0">

<img width="292" alt="image" src="https://github.com/Leets-Official/Leets-Garden-BE/assets/129377887/abeb7ae0-af46-4124-8c3e-81b6971da73a">

순서대로,
날짜가 예쁘게 들어간 모습입니다.
민규, 만규, 먼규 총 3명의 귀여운 친구들이 반환되는 모습입니다.

<br>

## 4. 완료 사항
close #35 
<br>

## 5. 추가 사항
